### PR TITLE
Add local OS keyring support so we don't have to req password

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,326 +2,205 @@
 
 
 [[projects]]
-  digest = "1:2aff5edb9bccd2974090fddb17ca7ab05a3f5c983db567c30c7f0b53404f5783"
   name = "github.com/ajg/form"
   packages = ["."]
-  pruneopts = "UT"
   revision = "cc2954064ec9ea8d93917f0f87456e11d7b881ad"
   version = "v1.5"
 
 [[projects]]
   branch = "master"
-  digest = "1:ef5b0622d834c139454148b8fd0c92bb314828900532b267ae62da9fec109866"
   name = "github.com/armon/go-metrics"
   packages = ["."]
-  pruneopts = "UT"
   revision = "f0300d1749da6fa982027e449ec0c7a145510c3c"
 
 [[projects]]
-  digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
-  name = "github.com/davecgh/go-spew"
-  packages = ["spew"]
-  pruneopts = "UT"
-  revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
-  version = "v1.1.1"
+  name = "github.com/danieljoos/wincred"
+  packages = ["."]
+  revision = "412b574fb496839b312a75fba146bd32a89001cf"
+  version = "v1.0.1"
 
 [[projects]]
-  digest = "1:76dc72490af7174349349838f2fe118996381b31ea83243812a97e5a0fd5ed55"
   name = "github.com/dgrijalva/jwt-go"
   packages = ["."]
-  pruneopts = "UT"
   revision = "06ea1031745cb8b3dab3f6a236daf2b0aa468b7e"
   version = "v3.2.0"
 
 [[projects]]
-  digest = "1:09d3ceb4456b0b463c5730198a9138e383089b27c0c10b1032789a0618a6dfe6"
   name = "github.com/dimfeld/httptreemux"
   packages = ["."]
-  pruneopts = "UT"
   revision = "a454a10de4a11f751681a0914461ab9e98c2a3ff"
   version = "5.0.2"
 
 [[projects]]
   branch = "master"
-  digest = "1:4f8e1481757861d07cf25c8fdcccfd77045510f2213a46bd79b5ee1ef90b5728"
   name = "github.com/fabric8-services/fabric8-auth-client"
   packages = ["auth"]
-  pruneopts = "UT"
   revision = "5e9eda695396296c02614e0ccb964404d4af08e6"
 
 [[projects]]
-  digest = "1:82dfb59e9bd5fccd4103731b6d5beafeb05308e160100065e7407950ce945c9f"
   name = "github.com/fabric8-services/fabric8-common"
-  packages = [
-    "auth",
-    "auth/jwk",
-    "configuration",
-    "errors",
-    "goasupport",
-    "httpsupport",
-    "log",
-  ]
-  pruneopts = "UT"
+  packages = ["auth","auth/jwk","configuration","errors","goasupport","httpsupport","log"]
   revision = "2efd83d29b1e5c657728e83fe03878569c0f122f"
 
 [[projects]]
-  digest = "1:abeb38ade3f32a92943e5be54f55ed6d6e3b6602761d74b4aab4c9dd45c18abd"
   name = "github.com/fsnotify/fsnotify"
   packages = ["."]
-  pruneopts = "UT"
   revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
   version = "v1.4.7"
 
 [[projects]]
-  digest = "1:b88761c32a2436cf7da8f2f6b9cdcb0b60a39f3f1004bece8945fd3ecc95c229"
   name = "github.com/goadesign/goa"
-  packages = [
-    ".",
-    "client",
-    "encoding/form",
-    "middleware",
-    "middleware/security/jwt",
-    "uuid",
-  ]
-  pruneopts = "UT"
+  packages = [".","client","encoding/form","middleware","middleware/security/jwt","uuid"]
   revision = "5646a430cdeb66983d5ace3384e0a667c185abc7"
   version = "v1.3.0"
 
 [[projects]]
-  digest = "1:2be5a35f0c5b35162c41bb24971e5dcf6ce825403296ee435429cdcc4e1e847e"
+  name = "github.com/godbus/dbus"
+  packages = ["."]
+  revision = "2ff6f7ffd60f0f2410b3105864bdd12c7894f844"
+  version = "v5.0.1"
+
+[[projects]]
   name = "github.com/hashicorp/go-immutable-radix"
   packages = ["."]
-  pruneopts = "UT"
   revision = "27df80928bb34bb1b0d6d0e01b9e679902e7a6b5"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:67474f760e9ac3799f740db2c489e6423a4cde45520673ec123ac831ad849cb8"
   name = "github.com/hashicorp/golang-lru"
   packages = ["simplelru"]
-  pruneopts = "UT"
   revision = "20f1fb78b0740ba8c3cb143a61e86ba5c8669768"
   version = "v0.5.0"
 
 [[projects]]
-  digest = "1:c0d19ab64b32ce9fe5cf4ddceba78d5bc9807f0016db6b1183599da3dcc24d10"
   name = "github.com/hashicorp/hcl"
-  packages = [
-    ".",
-    "hcl/ast",
-    "hcl/parser",
-    "hcl/printer",
-    "hcl/scanner",
-    "hcl/strconv",
-    "hcl/token",
-    "json/parser",
-    "json/scanner",
-    "json/token",
-  ]
-  pruneopts = "UT"
+  packages = [".","hcl/ast","hcl/parser","hcl/printer","hcl/scanner","hcl/strconv","hcl/token","json/parser","json/scanner","json/token"]
   revision = "8cb6e5b959231cc1119e43259c4a608f9c51a241"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:870d441fe217b8e689d7949fef6e43efbc787e50f200cb1e70dbca9204a1d6be"
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
-  pruneopts = "UT"
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
   version = "v1.0"
 
 [[projects]]
-  digest = "1:c568d7727aa262c32bdf8a3f7db83614f7af0ed661474b24588de635c20024c7"
   name = "github.com/magiconair/properties"
   packages = ["."]
-  pruneopts = "UT"
   revision = "c2353362d570a7bfa228149c62842019201cfb71"
   version = "v1.8.0"
 
 [[projects]]
-  digest = "1:53bc4cd4914cd7cd52139990d5170d6dc99067ae31c56530621b18b35fc30318"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
-  pruneopts = "UT"
   revision = "3536a929edddb9a5b34bd6861dc4a9647cb459fe"
   version = "v1.1.2"
 
 [[projects]]
-  digest = "1:95741de3af260a92cc5c7f3f3061e85273f5a81b5db20d4bd68da74bd521675e"
   name = "github.com/pelletier/go-toml"
   packages = ["."]
-  pruneopts = "UT"
   revision = "c01d1270ff3e442a8a57cddc1c92dc1138598194"
   version = "v1.2.0"
 
 [[projects]]
-  digest = "1:40e195917a951a8bf867cd05de2a46aaf1806c50cf92eebf4c16f78cd196f747"
   name = "github.com/pkg/errors"
   packages = ["."]
-  pruneopts = "UT"
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
 
 [[projects]]
-  digest = "1:274f67cb6fed9588ea2521ecdac05a6d62a8c51c074c1fccc6a49a40ba80e925"
   name = "github.com/satori/go.uuid"
   packages = ["."]
-  pruneopts = "UT"
   revision = "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3"
   version = "v1.2.0"
 
 [[projects]]
-  digest = "1:8011d6367a04c40f1a9f50274e5e22b1cd5c05104d87cd8cf21d5a56c0cc3bd8"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
-  pruneopts = "UT"
   revision = "ba1b36c82c5e05c4f912a88eab0dcd91a171688f"
   version = "v0.11.5"
 
 [[projects]]
-  digest = "1:d707dbc1330c0ed177d4642d6ae102d5e2c847ebd0eb84562d0dc4f024531cfc"
   name = "github.com/spf13/afero"
-  packages = [
-    ".",
-    "mem",
-  ]
-  pruneopts = "UT"
+  packages = [".","mem"]
   revision = "a5d6946387efe7d64d09dcba68cdd523dc1273a3"
   version = "v1.2.0"
 
 [[projects]]
-  digest = "1:08d65904057412fc0270fc4812a1c90c594186819243160dc779a402d4b6d0bc"
   name = "github.com/spf13/cast"
   packages = ["."]
-  pruneopts = "UT"
   revision = "8c9545af88b134710ab1cd196795e7f2388358d7"
   version = "v1.3.0"
 
 [[projects]]
-  digest = "1:645cabccbb4fa8aab25a956cbcbdf6a6845ca736b2c64e197ca7cbb9d210b939"
   name = "github.com/spf13/cobra"
   packages = ["."]
-  pruneopts = "UT"
   revision = "ef82de70bb3f60c65fb8eebacbb2d122ef517385"
   version = "v0.0.3"
 
 [[projects]]
-  digest = "1:68ea4e23713989dc20b1bded5d9da2c5f9be14ff9885beef481848edd18c26cb"
   name = "github.com/spf13/jwalterweatherman"
   packages = ["."]
-  pruneopts = "UT"
   revision = "4a4406e478ca629068e7768fc33f3f044173c0a6"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:dab83a1bbc7ad3d7a6ba1a1cc1760f25ac38cdf7d96a5cdd55cd915a4f5ceaf9"
   name = "github.com/spf13/pflag"
   packages = ["."]
-  pruneopts = "UT"
   revision = "9a97c102cda95a86cec2345a6f09f55a939babf5"
   version = "v1.0.2"
 
 [[projects]]
-  digest = "1:de37e343c64582d7026bf8ab6ac5b22a72eac54f3a57020db31524affed9f423"
   name = "github.com/spf13/viper"
   packages = ["."]
-  pruneopts = "UT"
   revision = "6d33b5a963d922d182c91e8a1c88d81fd150cfd4"
   version = "v1.3.1"
 
 [[projects]]
   branch = "master"
-  digest = "1:8e241498e35f550e5192ee6b1f6ff2c0a7ffe81feff9541d297facffe1383979"
+  name = "github.com/zalando/go-keyring"
+  packages = [".","secret_service"]
+  revision = "6d81c293b3fbc8a9b1bcf4bc9c167c2e1d1f52cf"
+
+[[projects]]
+  branch = "master"
   name = "golang.org/x/crypto"
-  packages = [
-    "ed25519",
-    "ed25519/internal/edwards25519",
-    "pbkdf2",
-    "ssh/terminal",
-  ]
-  pruneopts = "UT"
+  packages = ["ed25519","ed25519/internal/edwards25519","pbkdf2","ssh/terminal"]
   revision = "e3636079e1a4c1f337f212cc5cd2aca108f6c900"
 
 [[projects]]
   branch = "master"
-  digest = "1:1cbc8376888b3c65d233a36453909bb982819cded4d82268d5a1a0581dff1a47"
   name = "golang.org/x/net"
-  packages = [
-    "html",
-    "html/atom",
-    "idna",
-    "publicsuffix",
-    "websocket",
-  ]
-  pruneopts = "UT"
+  packages = ["html","html/atom","idna","publicsuffix","websocket"]
   revision = "03003ca0c849e57b6ea29a4bab8d3cb6e4d568fe"
 
 [[projects]]
   branch = "master"
-  digest = "1:6f82ed211591ecb407897ca46ff6149d618223088aecad72675804f106033629"
   name = "golang.org/x/sys"
-  packages = [
-    "unix",
-    "windows",
-  ]
-  pruneopts = "UT"
+  packages = ["unix","windows"]
   revision = "e4b3c5e9061176387e7cea65e4dc5853801f3fb7"
 
 [[projects]]
-  digest = "1:a2ab62866c75542dd18d2b069fec854577a20211d7c0ea6ae746072a1dccdd18"
   name = "golang.org/x/text"
-  packages = [
-    "collate",
-    "collate/build",
-    "internal/colltab",
-    "internal/gen",
-    "internal/tag",
-    "internal/triegen",
-    "internal/ucd",
-    "language",
-    "secure/bidirule",
-    "transform",
-    "unicode/bidi",
-    "unicode/cldr",
-    "unicode/norm",
-    "unicode/rangetable",
-  ]
-  pruneopts = "UT"
+  packages = ["collate","collate/build","internal/colltab","internal/gen","internal/tag","internal/triegen","internal/ucd","language","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable"]
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
-  digest = "1:feab1308bceeb3d0e078b1c10397f2ce3b9d6f030c209d46e8b6f62fc97f90f3"
   name = "gopkg.in/square/go-jose.v2"
-  packages = [
-    ".",
-    "cipher",
-    "json",
-  ]
-  pruneopts = "UT"
+  packages = [".","cipher","json"]
   revision = "72415094398e2f013bf50b76fd6de36df47938ea"
   version = "v2.2.1"
 
 [[projects]]
-  digest = "1:4d2e5a73dc1500038e504a8d78b986630e3626dc027bc030ba5c75da257cdb96"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  pruneopts = "UT"
   revision = "51d6538a90f86fe93ac480b35f37b2be17fef232"
   version = "v2.2.2"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  input-imports = [
-    "github.com/davecgh/go-spew/spew",
-    "github.com/fabric8-services/fabric8-common/auth",
-    "github.com/pkg/errors",
-    "github.com/sirupsen/logrus",
-    "github.com/spf13/cobra",
-    "golang.org/x/crypto/ssh/terminal",
-    "golang.org/x/net/html",
-    "golang.org/x/net/publicsuffix",
-  ]
+  inputs-digest = "7e716c4f1f17d15a0b254c741b6ba385d989156e90a1e7014f9477886bb5228a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -33,6 +33,13 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/fabric8-services/fabric8-auth-cli"
+  packages = ["cmd"]
+  revision = "018e066db6ad8784a43cfc11dd7dc7e48caf9934"
+  source = "github.com/xcoulon/fabric8-auth-cli"
+
+[[projects]]
+  branch = "master"
   name = "github.com/fabric8-services/fabric8-auth-client"
   packages = ["auth"]
   revision = "5e9eda695396296c02614e0ccb964404d4af08e6"
@@ -201,6 +208,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "7e716c4f1f17d15a0b254c741b6ba385d989156e90a1e7014f9477886bb5228a"
+  inputs-digest = "c8998dda6c6f7d7b0f4fd29399ebe800bc24a6ba817b7658d7253c3e9254bdba"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -32,4 +32,8 @@
 [[constraint]]
   name = "github.com/fabric8-services/fabric8-common"
   revision = "2efd83d29b1e5c657728e83fe03878569c0f122f"
-  
+
+[[constraint]]
+  name = "github.com/fabric8-services/fabric8-auth-cli"
+  branch = "master"
+  source = "github.com/xcoulon/fabric8-auth-cli"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -32,8 +32,3 @@
 [[constraint]]
   name = "github.com/fabric8-services/fabric8-common"
   revision = "2efd83d29b1e5c657728e83fe03878569c0f122f"
-
-[[constraint]]
-  name = "github.com/fabric8-services/fabric8-auth-cli"
-  branch = "master"
-  source = "github.com/xcoulon/fabric8-auth-cli"

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -51,6 +51,12 @@ func login(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	// If keyringUser is specified but not username then let's have the username as the keyringUser
+	if keyringUser != "" && username == "" {
+		username = keyringUser
+	}
+
 	if username == "" {
 		// prompt for username and password
 		fmt.Print("username: ")

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -61,7 +61,7 @@ func login(cmd *cobra.Command, args []string) {
 	}
 
 	// try to get password from keyring, it's okay if we can't find it (i.e: ignore error)
-	password, _ := keyring.Get(keyringUser, keyringService)
+	password, _ := keyring.Get(keyringService, keyringUser)
 
 	if password == "" {
 		fmt.Print("password: ")


### PR DESCRIPTION
It allows you to leverage your local OS keyring as supported by the library :

https://github.com/zalando/go-keyring

Example :

```bash
osio login -u username -t preview --keyring-user KEYRING_USER --keyring-service KEYRING_SERVICE
```

on OSX you can add your password to your keychain like this :

```bash
security add-generic-password -a KEYRING_USER -s KEYRING_SERVICE -w 'THE_PASSWORD_!!!_!!!'
```

(you may want to add a space before the cmd or clean your shell history after that)